### PR TITLE
Pin listen version so Ruby 2.1.x still works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+* Pin listen version so Ruby 2.1.x still works
+
 ## 0.1.1
 
 * CM-2587 Add Puppetfile, Vagrantfile & post-puppet.sh templates

--- a/skeleton/Gemfile
+++ b/skeleton/Gemfile
@@ -27,6 +27,7 @@ group :development do
   gem "travis-lint"
   gem "puppet-blacksmith"
   gem "guard-rake"
+  gem "listen", '~> 3.0.0'
 end
 
 group :system_tests do


### PR DESCRIPTION
```
Installing listen 3.1.1

Gem::InstallError: listen requires Ruby version ~> 2.2.
```
